### PR TITLE
Added parameters to freecompany_by_id to match upstream API

### DIFF
--- a/xivapi/client.py
+++ b/xivapi/client.py
@@ -142,16 +142,32 @@ class Client:
 
 
     @timed
-    async def freecompany_by_id(self, lodestone_id: int):
+    async def freecompany_by_id(self, lodestone_id: int, extended=False, include_freecompany_members=False):
         """|coro|
         Request Free Company data from XIVAPI.com by Lodestone ID
+        Please see XIVAPI documentation for more information about Free Company info at https://xivapi.com/docs/Free-Company#profile
         Parameters
         ------------
         lodestone_id: int
             The Free Company's Lodestone ID.
         """
-        url = f'{self.base_url}/freecompany/{lodestone_id}?private_key={self.api_key}'
-        async with self.session.get(url) as response:
+
+        params = {
+            "private_key": self.api_key
+        }
+
+        if extended is True:
+            params["extended"] = 1
+
+        data = []
+        if include_freecompany_members is True:
+            data.append("FCM")
+
+        if len(data) > 0:
+            params["data"] = ",".join(data)
+
+        url = f'{self.base_url}/freecompany/{lodestone_id}'
+        async with self.session.get(url, params=params) as response:
             return await self.process_response(response)
 
 


### PR DESCRIPTION
Working on a program that required iteration over each FC member, so I added functionality here to match the upstream API docs.  Code based on the `character_by_id` code.