### PR TITLE
Add support for ClassJobs in Character profile

### DIFF
--- a/pyxivapi/client.py
+++ b/pyxivapi/client.py
@@ -48,7 +48,7 @@ class XIVAPIClient:
 
 
     @timed
-    async def character_by_id(self, lodestone_id: int, extended=False, include_achievements=False, include_freecompany=False, include_freecompany_members=False, include_pvpteam=False, language="en"):
+    async def character_by_id(self, lodestone_id: int, extended=False, include_achievements=False, include_classjobs=False, include_freecompany=False, include_freecompany_members=False, include_pvpteam=False, language="en"):
         """|coro|
         Request character data from XIVAPI.com
         Please see XIVAPI documentation for more information about character sync state https://xivapi.com/docs/Character#character
@@ -72,6 +72,9 @@ class XIVAPIClient:
         data = []
         if include_achievements is True:
             data.append("AC")
+
+        if include_classjobs is True:
+            data.append("CJ")
 
         if include_freecompany is True:
             data.append("FC")


### PR DESCRIPTION
The client omits the ability to add the 'CJ' option onto a query, which makes it difficult to make a profile image generator in Python if you want it to show class levels. Simple change to add support.