### PR TITLE
Make sessions optional

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -104,3 +104,6 @@ venv.bak/
 .mypy_cache/
 .DS_Store
 example.py
+
+# pycharm
+.idea

--- a/README.md
+++ b/README.md
@@ -58,7 +58,7 @@ from pyxivapi.models import Filter, Sort
 
 
 async def fetch_example_results(session):
-    client = pyxivapi.XIVAPIClient(session=session, api_key="your_key_here")
+    client = pyxivapi.XIVAPIClient(api_key="your_key_here")
 
     # Search Lodestone for a character
     character = await client.character_search(
@@ -146,9 +146,6 @@ async def fetch_example_results(session):
 
 if __name__ == '__main__':
     logging.basicConfig(level=logging.INFO, format='%(message)s', datefmt='%H:%M')
-
-    loop = asyncio.get_event_loop()
-    session = aiohttp.ClientSession(loop=loop)
-    loop.run_until_complete(fetch_example_results(session))
+    loop.run_until_complete(fetch_example_results())
 
 ```

--- a/pyxivapi/client.py
+++ b/pyxivapi/client.py
@@ -1,5 +1,7 @@
 import logging
-from typing import List
+from typing import List, Optional
+
+from aiohttp import ClientSession
 
 from .exceptions import XIVAPIBadRequest, XIVAPIForbidden, XIVAPINotFound, XIVAPIServiceUnavailable, XIVAPIInvalidLanguage, XIVAPIError, XIVAPIInvalidIndex, XIVAPIInvalidColumns
 from .decorators import timed
@@ -13,19 +15,23 @@ class XIVAPIClient:
     Asynchronous client for accessing XIVAPI's endpoints.
     Parameters
     ------------
-    session: aiohttp.ClientSession()
-        The aiohttp session used with which to make http requests
     api_key: str
         The API key used for identifying your application with XIVAPI.com.
+    session: Optional[ClientSession]
+        Optionally include your aiohttp session
     """
+    base_url = "https://xivapi.com"
+    languages = ["en", "fr", "de", "ja"]
 
-    def __init__(self, session, api_key):
-        self.session = session
+    def __init__(self, api_key: str, session: Optional[ClientSession] = None) -> None:
         self.api_key = api_key
+        self._session = session
 
-        self.base_url = "https://xivapi.com"
-        self.languages = ["en", "fr", "de", "ja"]
-
+    @property
+    def session(self) -> ClientSession:
+        if self._session is None or self._session.closed:
+            self._session = ClientSession()
+        return self._session
 
     @timed
     async def character_search(self, world, forename, surname, page=1):


### PR DESCRIPTION
This PR should make the client self-contained. 

aiohttp fetches the running event loop ( https://github.com/aio-libs/aiohttp/blob/master/aiohttp/client.py#L206 ), so I don't see why passing in the loop or session is necessary

Possibly a breaking change for anyone using args instead of kwargs
